### PR TITLE
✨feature: DragAndDrop Svg support

### DIFF
--- a/base/src/lib/DragAndDrop.lib.avt
+++ b/base/src/lib/DragAndDrop.lib.avt
@@ -208,7 +208,7 @@ export class DragAndDrop {
         this.defaultMerge(options, "stopPropagation");
         this.defaultMerge(options, "useMouseFinalPosition");
         this.defaultMerge(options, "useTransform");
-        this.defaultMerge(options, "positionRelative");
+        this.defaultMerge(options, "svgRelativePosition");
         if(options.shadow !== void 0) {
             this.options.shadow.enable = options.shadow.enable;
             if(options.shadow.container !== void 0) {


### PR DESCRIPTION
What does it do ?
Add the support of SVGElement in DragAndDrop lib

Why ?
Main reasons to add this support is to be able to work with svg elements for example if you want to create a flow diagrams etc...

Tests
I've tested with this combination of svg elements :
![image](https://github.com/user-attachments/assets/97ef2c69-9936-4a33-8abc-3bc7f243d9da)


And I've also tested that it doesn't break DragAndDrop for HtmlElement